### PR TITLE
Added support for extending blueprints

### DIFF
--- a/config.php
+++ b/config.php
@@ -77,7 +77,7 @@ Kirby::plugin('steirico/kirby-plugin-custom-add-fields', [
                         }
                         try {
                             $props = Blueprint::load('pages/' . $template['name']);
-                            $addFields = A::get($props, 'addFields', null);
+                            $addFields = Blueprint::fieldsProps(A::get($props, 'addFields', null));
                             if($addFields){
                                 $dialogProperties = A::get($addFields, '__dialog', null);
                                 if($dialogProperties) {


### PR DESCRIPTION
This allows you to extend blueprints when defining addFields.
Example:
```
addFields:
  country:
    extends: section/field/country
    label: Select your country of residence
```