### PR TITLE
Fix/dialog

### DIFF
--- a/config.php
+++ b/config.php
@@ -6,20 +6,6 @@ Kirby::plugin('steirico/kirby-plugin-custom-add-fields', [
     'options' => [
         'forcedTemplate.fieldName' => 'forcedTemplate'
     ],
-    'translations' => [
-        'en' => [
-            'kirby-plugin-custom-add-fields.addBasedOnTemplate' => 'Add a new page based on this template',
-        ],
-        'de' => [
-            'kirby-plugin-custom-add-fields.addBasedOnTemplate' => 'Neue Seite basierend auf diesem Template hinzufügen',
-        ],
-        'fr' => [
-            'kirby-plugin-custom-add-fields.addBasedOnTemplate' => 'Ajouter une nouvelle page basée sur ce modèle',
-        ],
-        'it' => [
-            'kirby-plugin-custom-add-fields.addBasedOnTemplate' => 'Aggiungere una nuova pagina basata su questo modello',
-        ]
-    ],
 
     'api' => [
         'routes' => [
@@ -86,7 +72,7 @@ Kirby::plugin('steirico/kirby-plugin-custom-add-fields', [
                                 } else {
                                     $redirectToNewPage = false;
                                 }
-                                
+
 
                                 if(!empty($addFields)) {
                                     $fieldOrder = array_change_key_case($addFields, CASE_LOWER);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const PAGE_CREATE_DIALOG = {
       <k-form
         ref="form"
         :fields="fields"
-        :novalidate="false"
+        :novalidate="true"
         :key="template"
         v-model="page"
         @submit="submit"
@@ -27,7 +27,7 @@ const PAGE_CREATE_DIALOG = {
       section: null,
       templates: [],
       template: '',
-      page: {},
+      page: this.emptyForm(),
       addFields: {}
     };
   },
@@ -62,7 +62,7 @@ const PAGE_CREATE_DIALOG = {
 
       fields.template = {
         name: "template",
-        label: this.$t("kirby-plugin-custom-add-fields.addBasedOnTemplate"),
+        label: this.$t("template"),
         type: "select",
         disabled: this.templates.length === 1,
         required: true,
@@ -179,7 +179,7 @@ const PAGE_CREATE_DIALOG = {
       if (this.isValid()){
         var data = {};
         var route = '';
-        
+
         if(pageData.skipDialog){
           data = pageData.page;
         } else {
@@ -192,7 +192,7 @@ const PAGE_CREATE_DIALOG = {
 
         delete data.content.addFields;
         delete data.content.template;
-   
+
         this.$api
           .post(this.parent + "/children", data)
           .then(page => {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const PAGE_CREATE_DIALOG = {
   template: `
     <k-dialog
       ref="dialog"
-      :button="$t('page.draft.create')"
+      :submit-button="$t('page.draft.create')"
       :notification="notification"
       size="medium"
       theme="positive"

--- a/index.js
+++ b/index.js
@@ -161,6 +161,7 @@ const PAGE_CREATE_DIALOG = {
         invalid = false;
 
       if(form) {
+        form.novalidate = false;
         errors = form.$refs.fields.errors;
         invalid = true;
 

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ const PAGE_CREATE_DIALOG = {
       section: null,
       templates: [],
       template: '',
-      page: this.emptyForm(),
+      page: {},
       addFields: {}
     };
   },


### PR DESCRIPTION
This commit adapts the dialog UI to the Panel’s current default layout.
It also makes sure fields are not validated on load and that the submit button is correctly labeled.

Fixes #29