### PR TITLE
Redirect improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ If desired, redirect to the newly created page is possible on a per blueprint ba
 >           redirect: true
 >   ```
 
+If redirection to another page after creation is required, `redirect` can be set to that page id.
+
 ### Force a specific Template
 
 The template to be used for the new page can be forced by a field of the current page. By default,

--- a/index.js
+++ b/index.js
@@ -199,7 +199,11 @@ const PAGE_CREATE_DIALOG = {
           .post(this.parent + "/children", data)
           .then(page => {
             if(this.options && this.options.redirectToNewPage) {
-              route = this.$api.pages.link(page.id);
+              if(this.options.redirectToNewPage === true) {
+                route = this.$api.pages.link(page.id);
+              } else if (this.options.redirectToNewPage !== false) {
+                route = this.$api.pages.link(this.options.redirectToNewPage);
+              }
             } else {
               route = page.parent ? this.$api.pages.link(page.parent.id) : '/';
             }
@@ -209,7 +213,6 @@ const PAGE_CREATE_DIALOG = {
               message: ":)",
               event: "page.create"
             });
-            this.$router.go();
           })
           .catch(error => {
             this.$refs.dialog.error(error.message);


### PR DESCRIPTION
- fixes redirection to new page (removing line 212)
- adds custom redirects by specifying a static page id as target:
  ```yaml
  __dialog:
    redirect: my/page/id
  ```
  This can be helpful if you're adding content on the site index and want to redirect back there after. Otherwise and without this change, the parent of the pages section would be used.