### PR TITLE
fix: Check if model name is not null

### DIFF
--- a/config.php
+++ b/config.php
@@ -158,7 +158,7 @@ Kirby::plugin('steirico/kirby-plugin-custom-add-fields', [
         'page.create:after' => function ($page) {
             $modelName = a::get(Page::$models, $page->intendedTemplate()->name());
 
-            if(method_exists($modelName, 'hookPageCreate')){
+            if(null !== $modelName && method_exists($modelName, 'hookPageCreate')){
                 $modelName::hookPageCreate($page);
             }
         }


### PR DESCRIPTION
Before passing it to the method_exists, we should check if model name is not null.
Prior to PHP 8, this resulted in a PHP warning, but now throws an Exception.